### PR TITLE
Update site.conf

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -8,7 +8,7 @@
 	prefix6 = '2a03:2260:50:4::/64',
 
 	timezone = 'CET-1CEST,M3.5.0,M10.5.0/3', -- Europe/Berlin
-	ntp_servers = {'1.ntp.services.ffrg','2.ntp.services.ffrg', 'ntp1.ptb.de'},
+	ntp_servers = {'1.ntp.services.ffrg','2.ntp.services.ffrg', 'de.pool.ntp.org', 'ntp1.ptb.de'},
 	regdom = 'DE',
 
 	wifi24 = {
@@ -23,8 +23,8 @@
 		ssid = 'Freifunk',
 		channel = 40,
 		htmode = 'HT40+',
-		mesh_ssid = 'mesh.ffel',
-		mesh_bssid = '02:ff:13:37:ff:07',
+		mesh_ssid = 'mesh5.ffel',
+		mesh_bssid = '02:ff:13:37:ff:17',
 		mesh_mcast_rate = 12000,
 	},
 
@@ -56,6 +56,12 @@
 						'ipv4 "node02-2.el.freifunk.ruhr" port 10000',
 						'ipv6 "node02-2.el.freifunk.ruhr" port 10000'
 					},
+				fallback = {
+					key = '15e1601791c201e463ca404ae9174f937859346ef1b7311a3e9eebf02fe6ebbe',
+					remotes = {
+						'ipv4 "fallback.freifunk-emscherland.de" port 10000',
+						'ipv6 "fallback.freifunk-emscherland.de" port 10000'
+					},
 				},
 			},
 		},
@@ -70,26 +76,8 @@
 				probability = 0.08,
 				good_signatures = 1,
 				pubkeys = {
-					'6f6104f1e069dd4390fd7b88eb12b27241ba0eb1f87d36c4b9f7724d81d67f72', -- Chris
-					'4bcf080d3937310ea3f5ee3678bff5c839679b69c8b2529ba1371b710dd046b6', -- Philip
-				},
-			},
-			beta = {
-				name = 'beta',
-				mirrors = {'http://images.freifunk-emscherland.de/beta/sysupgrade','http://1.updates.services.ffel/beta/sysupgrade'},
-				probability = 0.08,
-				good_signatures = 1,
-				pubkeys = {
-					'6f6104f1e069dd4390fd7b88eb12b27241ba0eb1f87d36c4b9f7724d81d67f72', -- Chris
-					'4bcf080d3937310ea3f5ee3678bff5c839679b69c8b2529ba1371b710dd046b6', -- Philip
-				},
-			},
-			experimental = {
-				name = 'experimental',
-				mirrors = {'http://images.freifunk-emscherland.de/beta/sysupgrade','http://1.updates.services.ffel/experimental/sysupgrade'},
-				probability = 0.08,
-				good_signatures = 1,
-				pubkeys = {
+					'0000000000000000000000000000000000000000000000000000000000000000', -- Daniel
+					'19a02dd7b50ffc2b59e2cd1f9e76b26b46e33c43ebf641554572e4a677af35cc', -- Michael
 					'6f6104f1e069dd4390fd7b88eb12b27241ba0eb1f87d36c4b9f7724d81d67f72', -- Chris
 					'4bcf080d3937310ea3f5ee3678bff5c839679b69c8b2529ba1371b710dd046b6', -- Philip
 				},
@@ -101,8 +89,8 @@
 		mesh_vpn = {
 			ifname = 'mesh-vpn',
 			enabled = false,
-			limit_egress = 4000,
-			limit_ingress = 30000,
+			limit_egress = 10000,
+			limit_ingress = 50000,
 		},
 	},
 }


### PR DESCRIPTION
- Added 'de.pool.ntp.org' to ntp_servers (just for the lulz)
- Changed wifi5 mesh_ssid to 'mesh5.ffel' and mesh_bssid to '02:ff:13:37:ff:17' to avoid conflicts (was identical to wifi24)
- Added fallback to backbone per group
- Removed 'beta' and 'experimental' branches from autoupdater
- Added placeholder pubkey for Daniel
- Added pubkey for Michael
- Changed simple_tc defaults