### PR TITLE
Update site.mk

### DIFF
--- a/site.mk
+++ b/site.mk
@@ -14,7 +14,6 @@ GLUON_SITE_PACKAGES := \
         gluon-ebtables-filter-ra-dhcp \
         gluon-luci-admin \
         gluon-luci-autoupdater \
-        gluon-luci-mesh-vpn-fastd \
         gluon-luci-portconfig \
         gluon-luci-private-wifi \
         gluon-luci-wifi-config \
@@ -27,7 +26,7 @@ GLUON_SITE_PACKAGES := \
         haveged
 
 
-DEFAULT_GLUON_RELEASE := 0.7.2
+DEFAULT_GLUON_RELEASE := 0.7.3
 
 # Allow overriding the release number from the command line
 GLUON_RELEASE ?= $(DEFAULT_GLUON_RELEASE)


### PR DESCRIPTION
- Removed luci-fastd-Configuration since null-cipher is not supported by supernodes
- Increased DEFAULT_GLUON_RELEASE to 0.7.3 to force update of manually created 0.7.2 firmware (e.g. refugee housings)